### PR TITLE
Add annotations to add DNS for Jenkins

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -3,6 +3,9 @@ kind: Service
 metadata:
   name: jenkins
   namespace: jenkins
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: "jenkins.connect.cd"
+    external-dns.alpha.kubernetes.io/ttl: "10"
 spec:
   externalTrafficPolicy: Cluster
   ports:


### PR DESCRIPTION
These annotations should ensure that the DNS record gets added when the
service is created and points to the ELB created.

The thing that picks up the annotations and ensures that the DNS record
is in place is the "external-dns" Deployment, running in the "default"
namespace.

This looks to be based off of the:

  registry.opensource.zalan.do/teapot/external-dns:v0.4.5

Docker image.

Issue(s): None