### PR TITLE
Change Sample Apps repo to GitHub

### DIFF
--- a/jobs/meta-job/config.xml
+++ b/jobs/meta-job/config.xml
@@ -8,7 +8,7 @@
     <configVersion>2</configVersion>
     <userRemoteConfigs>
       <hudson.plugins.git.UserRemoteConfig>
-        <url>git@bitbucket.org:clearpoint/connect-sample-apps.git</url>
+        <url>git@github.com:ClearPointNZ/connect-sample-apps.git</url>
         <credentialsId>jenkins-clearpoint</credentialsId>
       </hudson.plugins.git.UserRemoteConfig>
     </userRemoteConfigs>


### PR DESCRIPTION
The repository has been moved to GitHub from BitBucket. Therefore
making the bootstrap meta job reflect this reality.

Issue(s): None