### PR TITLE
Change the path to the Groovy DSL to "build"

### DIFF
--- a/jobs/meta-job/config.xml
+++ b/jobs/meta-job/config.xml
@@ -34,7 +34,7 @@
   <concurrentBuild>false</concurrentBuild>
   <builders>
     <javaposse.jobdsl.plugin.ExecuteDslScripts>
-      <targets>jobs/**/*.groovy</targets>
+      <targets>**/build/*.groovy</targets>
       <usingScriptText>false</usingScriptText>
       <scriptText/>
       <ignoreExisting>false</ignoreExisting>


### PR DESCRIPTION
Make it so that the build definition for each application lives in the
same directory as the application under a well defined location (i.e. a
sub-directory called "build").

This makes the directory structure:

```
sample-apps
|-- slack-message-reader
|   `-- build
|       |-- pipeline_job.groovy
|       `-- Jenkinsfile
|-- slack-sentiment-analyser
|   `-- build
|       |-- pipeline_job.groovy
|       `-- Jenkinsfile
.       .
.       .
.       .
```

Issue(s): None