### PR TITLE
Change Jenkins worker configuration to use DNS

### DIFF
--- a/overrides/config.xml.override
+++ b/overrides/config.xml.override
@@ -138,7 +138,7 @@
           </default>
           <int>1</int>
           <string>JENKINS_REAL_URL</string>
-          <string>http://${MY_POD_IP}:8080</string>
+          <string>http://jenkins:8080</string>
         </tree-map>
       </envVars>
     </hudson.slaves.EnvironmentVariablesNodeProperty>


### PR DESCRIPTION
It looks like the IP that the Jenkins server uses changes, therefore, changing it to use the internal cluster DNS. This should work as we can assume there will always be a "jenkins" service.