### PR TITLE
Add Jenkins Helm configuration values

### DIFF
--- a/jenkins_config.yaml
+++ b/jenkins_config.yaml
@@ -1,0 +1,18 @@
+Master:
+  InstallPlugins:
+    - workflow-job:2.15
+    - workflow-aggregator:latest
+    - branch-api:2.0.14
+    - git:latest
+    - kubernetes:latest
+    - credentials:latest
+    - credentials-binding:latest
+    - job-dsl:latest
+    - kubernetes-pipeline-steps:latest
+rbac:
+  install: true
+  serviceAccountName: helm-jenkins
+  # RBAC api version (currently either v1beta1 or v1alpha1)
+  apiVersion: v1beta1
+  # Cluster role reference
+  roleRef: cluster-admin


### PR DESCRIPTION
Can be applied with:

  helm install --name helm-jenkins -f jenkins_config.yaml --set Master.AdminPassword=CHANGEMEPLEASE stable/jenkins

Currently it just installs the plugins we need and enables RBAC.

Still need to get it to:
* Auto add the Nexus server credentials
* Auto add the "meta" job

Issue(s): None